### PR TITLE
Update DG Headings and Subheadings 

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -220,19 +220,19 @@ _{Explain here how the data archiving feature will be implemented}_
 
 --------------------------------------------------------------------------------------------------------------------
 
-## 4. **Documentation**
+## **4. Documentation**
 * [Documentation guide](Documentation.md)
 
-## 5. **Testing**
+## **5. Testing**
 * [Testing guide](Testing.md)
 
-## 6. **Logging**
+## **6. Logging**
 * [Logging guide](Logging.md)
 
-## 7. **Configuration**
+## **7. Configuration**
 * [Configuration guide](Configuration.md)
 
-## 8. **Dev-ops**
+## **8. Dev-ops**
 * [DevOps guide](DevOps.md)
 
 --------------------------------------------------------------------------------------------------------------------

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -7,15 +7,15 @@ title: Developer Guide
 
 --------------------------------------------------------------------------------------------------------------------
 
-## **Setting up, getting started**
+## **1. Setting up, getting started**
 
 Refer to the guide [_Setting up and getting started_](SettingUp.md).
 
 --------------------------------------------------------------------------------------------------------------------
 
-## **Design**
+## **2. Design**
 
-### Architecture
+### 2.1 Architecture
 
 <img src="images/ArchitectureDiagram.png" width="450" />
 
@@ -57,7 +57,7 @@ The *Sequence Diagram* below shows how the components interact with each other f
 
 The sections below give more details of each component.
 
-### UI component
+### 2.2 UI component
 
 ![Structure of the UI Component](images/UiClassDiagram.png)
 
@@ -73,7 +73,7 @@ The `UI` component,
 * Executes user commands using the `Logic` component.
 * Listens for changes to `Model` data so that the UI can be updated with the modified data.
 
-### Logic component
+### 2.3 Logic component
 
 ![Structure of the Logic Component](images/LogicClassDiagram.png)
 
@@ -93,7 +93,7 @@ Given below is the Sequence Diagram for interactions within the `Logic` componen
 <div markdown="span" class="alert alert-info">:information_source: **Note:** The lifeline for `DeleteCommandParser` should end at the destroy marker (X) but due to a limitation of PlantUML, the lifeline reaches the end of diagram.
 </div>
 
-### Model component
+### 2.4 Model component
 
 ![Structure of the Model Component](images/ModelClassDiagram.png)
 
@@ -113,7 +113,7 @@ The `Model`,
 </div>
 
 
-### Storage component
+### 2.5 Storage component
 
 ![Structure of the Storage Component](images/StorageClassDiagram.png)
 
@@ -123,19 +123,19 @@ The `Storage` component,
 * can save `UserPref` objects in json format and read it back.
 * can save the patient data in json format and read it back.
 
-### Common classes
+### 2.6 Common classes
 
 Classes used by multiple components are in the `seedu.addressbook.commons` package.
 
 --------------------------------------------------------------------------------------------------------------------
 
-## **Implementation**
+## **3. Implementation**
 
 This section describes some noteworthy details on how certain features are implemented.
 
-### \[Proposed\] Undo/redo feature
+### 3.1 Undo/redo feature
 
-#### Proposed Implementation
+#### 3.1.1 Implementation
 
 The proposed undo/redo mechanism is facilitated by `VersionedCliniCal`. It extends `CliniCal` with an undo/redo history, stored internally as an `CliniCalStateList` and `currentStatePointer`. Additionally, it implements the following operations:
 
@@ -198,9 +198,9 @@ The following activity diagram summarizes what happens when a user executes a ne
 
 ![CommitActivityDiagram](images/CommitActivityDiagram.png)
 
-#### Design consideration:
+#### 3.1.2 Design consideration:
 
-##### Aspect: How undo & redo executes
+##### 3.1.2.1 Aspect: How undo & redo executes
 
 * **Alternative 1 (current choice):** Saves the entire patient details in CliniCal application.
   * Pros: Easy to implement.
@@ -213,26 +213,31 @@ The following activity diagram summarizes what happens when a user executes a ne
 
 _{more aspects and alternatives to be added}_
 
-### \[Proposed\] Data archiving
+### 3.2 \[Proposed\] Data archiving
 
 _{Explain here how the data archiving feature will be implemented}_
 
 
 --------------------------------------------------------------------------------------------------------------------
 
-## **Documentation, logging, testing, configuration, dev-ops**
-
+## 4. **Documentation**
 * [Documentation guide](Documentation.md)
+
+## 5. **Testing**
 * [Testing guide](Testing.md)
+
+## 6. **Logging**
 * [Logging guide](Logging.md)
+
+## 7. **Configuration**
 * [Configuration guide](Configuration.md)
+
+## 8. **Dev-ops**
 * [DevOps guide](DevOps.md)
 
 --------------------------------------------------------------------------------------------------------------------
 
-## **Appendix: Requirements**
-
-### Product scope
+## **Appendix A: Product scope**
 
 **Target user profile**:
 
@@ -245,7 +250,7 @@ _{Explain here how the data archiving feature will be implemented}_
 **Value proposition**: provide a platform for doctors to manage their upcoming appointments and access patient's medical records more easily
 
 
-### User stories
+## **Appendix B: User stories**
 
 Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unlikely to have) - `*`
 
@@ -266,7 +271,7 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 
 *{More to be added}*
 
-### Use cases
+## **Appendix C: Use Cases**
 
 (For all use cases below, the **System** is the `CliniCal` and the **Actor** is the `user`, unless specified otherwise)
 
@@ -334,7 +339,7 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 
 *{More to be added}*
 
-### Non-Functional Requirements
+## **Appendix D: Non-Functional Requirements** 
 
 1. Should work on any mainstream OS as long as it has Java `11` installed.
 1. Should be able to hold up to 1000 patients without a noticeable sluggishness in performance for typical usage.
@@ -343,7 +348,7 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 
 *{More to be added}*
 
-### Glossary
+## **Appendix E: Glossary**
 
 * **Mainstream OS**: Windows, Linux, Unix, OS-X
 * **Patient records**: Extensive collection of patients’ private information (not meant to be shared) and medical histories.
@@ -351,7 +356,7 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 
 --------------------------------------------------------------------------------------------------------------------
 
-## **Appendix: Instructions for manual testing**
+## **Appendix F: Instructions for manual testing**
 
 Given below are instructions to test the app manually.
 
@@ -360,7 +365,7 @@ testers are expected to do more *exploratory* testing.
 
 </div>
 
-### Launch and shutdown
+### F.1 Launch and shutdown
 
 1. Initial launch
 
@@ -377,7 +382,7 @@ testers are expected to do more *exploratory* testing.
 
 1. _{ more test cases …​ }_
 
-### Deleting a patient
+### F.2 Deleting a patient
 
 1. Deleting a patient while all patients are being shown
 
@@ -394,7 +399,7 @@ testers are expected to do more *exploratory* testing.
 
 1. _{ more test cases …​ }_
 
-### Saving data
+### F.3 Saving data
 
 1. Dealing with missing/corrupted data files
 


### PR DESCRIPTION
Improved DG table of contents: 

![updated DG toc](https://user-images.githubusercontent.com/47620989/95657752-bc526780-0b48-11eb-867e-352d486b8b82.png)

Also removed 'proposed' in the undo/redo implementation details