### PR TITLE
Fix bug in CommandBox

### DIFF
--- a/src/main/java/seedu/address/ui/CommandBox.java
+++ b/src/main/java/seedu/address/ui/CommandBox.java
@@ -39,7 +39,6 @@ public class CommandBox extends UiPart<Region> {
             if (e.getCode().equals(KeyCode.UP)) {
                 commandTextField.setText(CommandHistory.peekNext());
             }
-            commandTextField.end();
         });
     }
 


### PR DESCRIPTION
The bug is preventing the user from editing the text properly so users have to backspace and retype to make changes.