### PR TITLE
Stop codecov from failing CI

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -42,4 +42,4 @@ jobs:
         if: runner.os == 'Linux'
         with:
           file: ${{ github.workspace }}/build/reports/jacoco/coverage/coverage.xml
-          fail_ci_if_error: true
+          fail_ci_if_error: false


### PR DESCRIPTION
Currently, decreasing code coverage would fail CI (GItHub Actions). This will become problematic as we add in more UI code, which is not testable with cases.